### PR TITLE
Add multiple complexity levels for creature generaiton.

### DIFF
--- a/lib/pages/creature-page.tsx
+++ b/lib/pages/creature-page.tsx
@@ -392,6 +392,7 @@ export const CreaturePage: React.FC<{}> = () => {
   const [symbolCtx, setSymbolCtx] = useState(createSvgSymbolContext());
   const [complexity, setComplexity] = useState(MAX_COMPLEXITY_LEVEL);
   const defaultCtx = useContext(CreatureContext);
+  const newRandomSeed = () => setRandomSeed(Date.now());
   const ctx: CreatureContextType = {
     ...defaultCtx,
     ...symbolCtx,
@@ -425,13 +426,13 @@ export const CreaturePage: React.FC<{}> = () => {
           value={complexity}
           onChange={(e) => {
             setComplexity(parseInt(e.target.value));
-            setRandomSeed(Date.now());
+            newRandomSeed();
           }}
         />{" "}
         {complexity === MAX_COMPLEXITY_LEVEL ? "bonkers" : complexity}
       </p>
       <p>
-        <button accessKey="r" onClick={() => setRandomSeed(Date.now())}>
+        <button accessKey="r" onClick={newRandomSeed}>
           <u>R</u>andomize!
         </button>{" "}
         <button onClick={() => window.location.reload()}>Reset</button>{" "}

--- a/lib/random.test.ts
+++ b/lib/random.test.ts
@@ -1,0 +1,28 @@
+import { Random } from "./random";
+
+describe("choice()", () => {
+  it("works", () => {
+    expect(new Random().choice([1])).toBe(1);
+    expect(new Random(134).choice([1, 5, 9, 7])).toBe(5);
+  });
+
+  it("throws an error if passed an empty array", () => {
+    expect(() => new Random().choice([])).toThrow(
+      /Cannot choose randomly from an empty array/
+    );
+  });
+});
+
+describe("uniqueChoices()", () => {
+  it("works", () => {
+    expect(new Random(3).uniqueChoices([1, 2, 3], 2)).toEqual([1, 3]);
+  });
+
+  it("returns fewer choices than asked if necessary", () => {
+    expect(new Random().uniqueChoices([1, 1, 1], 5)).toEqual([1]);
+  });
+
+  it("returns an empty array if needed", () => {
+    expect(new Random().uniqueChoices([], 5)).toEqual([]);
+  });
+});

--- a/lib/random.ts
+++ b/lib/random.ts
@@ -36,10 +36,34 @@ export class Random {
   }
 
   /**
-   * Return a random item from the given array.
+   * Return a random item from the given array. If the array is
+   * empty, an exception is thrown.
    */
   choice<T>(array: T[]): T {
+    if (array.length === 0) {
+      throw new Error("Cannot choose randomly from an empty array!");
+    }
     const idx = Math.floor(this.next() * array.length);
     return array[idx];
+  }
+
+  /**
+   * Attempt to randomly choose *at most* the given number of unique items from
+   * the array. If the array is too small, fewer items are returned.
+   */
+  uniqueChoices<T>(array: T[], howMany: number): T[] {
+    let choicesLeft = [...array];
+    const result: T[] = [];
+
+    for (let i = 0; i < howMany; i++) {
+      if (choicesLeft.length === 0) {
+        break;
+      }
+      const choice = this.choice(choicesLeft);
+      choicesLeft = choicesLeft.filter((item) => item !== choice);
+      result.push(choice);
+    }
+
+    return result;
   }
 }

--- a/lib/util.test.tsx
+++ b/lib/util.test.tsx
@@ -1,4 +1,4 @@
-import { flatten, float, rad2deg } from "./util";
+import { flatten, float, rad2deg, range } from "./util";
 
 describe("float", () => {
   it("converts strings", () => {
@@ -24,4 +24,10 @@ test("rad2deg() works", () => {
   expect(rad2deg(Math.PI)).toBe(180);
   expect(rad2deg(Math.PI - 0.0000001)).toBeCloseTo(180);
   expect(rad2deg(2 * Math.PI)).toBe(360);
+});
+
+test("range() works", () => {
+  expect(range(0)).toEqual([]);
+  expect(range(1)).toEqual([0]);
+  expect(range(5)).toEqual([0, 1, 2, 3, 4]);
 });

--- a/lib/util.ts
+++ b/lib/util.ts
@@ -28,6 +28,10 @@ export function rad2deg(radians: number): number {
   return (radians * 180) / Math.PI;
 }
 
+/**
+ * Return an array containing the numbers from 0 to one
+ * less than the given value, increasing.
+ */
 export function range(count: number): number[] {
   const result: number[] = [];
   for (let i = 0; i < count; i++) {

--- a/lib/util.ts
+++ b/lib/util.ts
@@ -27,3 +27,12 @@ export function flatten<T>(arr: T[][]): T[] {
 export function rad2deg(radians: number): number {
   return (radians * 180) / Math.PI;
 }
+
+export function range(count: number): number[] {
+  const result: number[] = [];
+  for (let i = 0; i < count; i++) {
+    result.push(i);
+  }
+
+  return result;
+}


### PR DESCRIPTION
Fixes #18 by adding a random creature complexity slider. Currently slider values are 0, 1, 2, 3, 4, and bonkers.

> ![image](https://user-images.githubusercontent.com/124687/108796826-ab365000-7557-11eb-8426-05749896506f.png)
