### PR TITLE
Add basic support for nesting.

### DIFF
--- a/lib/bounding-box.test.ts
+++ b/lib/bounding-box.test.ts
@@ -1,0 +1,72 @@
+import { BBox } from "../vendor/bezier-js";
+import { uniformlyScaleToFit } from "./bounding-box";
+
+describe("uniformlyScaleToFit()", () => {
+  it("returns 1 for identical boxes", () => {
+    const box: BBox = {
+      x: { min: 0, max: 1 },
+      y: { min: 0, max: 1 },
+    };
+    expect(uniformlyScaleToFit(box, box)).toBe(1.0);
+  });
+
+  it("returns 1 for identically-sized boxes", () => {
+    const box1: BBox = {
+      x: { min: 0, max: 1 },
+      y: { min: 0, max: 1 },
+    };
+    const box2: BBox = {
+      x: { min: -5, max: -4 },
+      y: { min: -20, max: -19 },
+    };
+    expect(uniformlyScaleToFit(box1, box2)).toBe(1.0);
+  });
+
+  it("returns 2 when child is half the size of parent", () => {
+    const parent: BBox = {
+      x: { min: 0, max: 1 },
+      y: { min: 0, max: 1 },
+    };
+    const child: BBox = {
+      x: { min: 0, max: 0.5 },
+      y: { min: 0, max: 0.5 },
+    };
+    expect(uniformlyScaleToFit(parent, child)).toBe(2.0);
+  });
+
+  it("returns 0.5 when child is twice the size of parent", () => {
+    const parent: BBox = {
+      x: { min: 0, max: 1 },
+      y: { min: 0, max: 1 },
+    };
+    const child: BBox = {
+      x: { min: 0, max: 2 },
+      y: { min: 0, max: 2 },
+    };
+    expect(uniformlyScaleToFit(parent, child)).toBe(0.5);
+  });
+
+  it("returns 1 when child is same width as parent but shorter", () => {
+    const parent: BBox = {
+      x: { min: 0, max: 1 },
+      y: { min: 0, max: 1 },
+    };
+    const child: BBox = {
+      x: { min: 0, max: 1 },
+      y: { min: 0, max: 0.1 },
+    };
+    expect(uniformlyScaleToFit(parent, child)).toBe(1);
+  });
+
+  it("returns 1 when child is same height as parent but thinner", () => {
+    const parent: BBox = {
+      x: { min: 0, max: 1 },
+      y: { min: 0, max: 1 },
+    };
+    const child: BBox = {
+      x: { min: 0, max: 0.1 },
+      y: { min: 0, max: 1 },
+    };
+    expect(uniformlyScaleToFit(parent, child)).toBe(1);
+  });
+});

--- a/lib/bounding-box.ts
+++ b/lib/bounding-box.ts
@@ -91,3 +91,18 @@ export function getSvgBoundingBox(
       return getPathBoundingBox(element.props);
   }
 }
+
+/**
+ * Assuming the origins of the giving boxes are aligned and
+ * the transform origin is set to their center, return the maximum
+ * amount the child needs to be scaled to fit within the parent.
+ */
+export function uniformlyScaleToFit(parent: BBox, child: BBox): number {
+  const [pWidth, pHeight] = getBoundingBoxSize(parent);
+  const [cWidth, cHeight] = getBoundingBoxSize(child);
+
+  const widthScale = pWidth / cWidth;
+  const heightScale = pHeight / cHeight;
+
+  return Math.min(widthScale, heightScale);
+}

--- a/lib/pages/creature-page.tsx
+++ b/lib/pages/creature-page.tsx
@@ -112,27 +112,23 @@ function getAttachmentIndices(ai: AttachmentIndices): number[] {
 }
 
 type SplitCreatureSymbolChildren = {
-  attachments?: JSX.Element[];
-  nests?: JSX.Element[];
+  attachments: JSX.Element[];
+  nests: JSX.Element[];
 };
 
 function splitCreatureSymbolChildren(
   children?: AttachmentChildren
 ): SplitCreatureSymbolChildren {
-  if (!children) return {};
-
-  const result: SplitCreatureSymbolChildren = {};
+  const result: SplitCreatureSymbolChildren = {
+    attachments: [],
+    nests: [],
+  };
+  if (!children) return result;
 
   React.Children.forEach(children, (child) => {
     if (child.props.nestInside) {
-      if (!result.nests) {
-        result.nests = [];
-      }
       result.nests.push(child);
     } else {
-      if (!result.attachments) {
-        result.attachments = [];
-      }
       result.attachments.push(child);
     }
   });
@@ -151,13 +147,13 @@ const CreatureSymbol: React.FC<CreatureSymbolProps> = (props) => {
   // should be after our symbol so they appear in front of it.
   const ourSymbol = (
     <>
-      {attachments && (
+      {attachments.length && (
         <CreatureContext.Provider value={childCtx}>
           {attachments}
         </CreatureContext.Provider>
       )}
       <SvgSymbolContent data={data} {...ctx} />
-      {nests && (
+      {nests.length && (
         <CreatureContext.Provider value={childCtx}>
           {nests}
         </CreatureContext.Provider>

--- a/lib/pages/creature-page.tsx
+++ b/lib/pages/creature-page.tsx
@@ -344,6 +344,8 @@ const Leg = createCreatureSymbol("leg");
 
 const Tail = createCreatureSymbol("tail");
 
+const Lightning = createCreatureSymbol("lightning");
+
 function getSymbolWithAttachments(
   numAttachmentKinds: number,
   rng: Random
@@ -375,7 +377,7 @@ function getSymbolWithAttachments(
 
 const EYE_CREATURE = (
   <Eye>
-    <Crown nestInside />
+    <Lightning nestInside />
     <Arm attachTo="arm" left>
       <Wing attachTo="arm" left right />
     </Arm>


### PR DESCRIPTION
This adds basic support for nesting (#17).  It does not swap fill/stroke colors based on the position of the nesting box, though. It also only nests a symbol in the eye creature and "bonkers" complexity setting for now--support for nesting in complexity levels 1-4 is forthcoming.

Here's what the eye creature looks like now:

> ![image](https://user-images.githubusercontent.com/124687/109248465-dd43ee00-77b3-11eb-904f-4a460866aa2e.png)

And here's what it looks like with specs showing:

> ![image](https://user-images.githubusercontent.com/124687/109248516-f2b91800-77b3-11eb-9b9e-ace24525e0e9.png)

So the nested symbol is essentially uniformly scaled as much as possible without extending outside the boundaries of its parent's nesting box.