### PR TITLE
Massively refactor and simplify creature-symbol.tsx.

### DIFF
--- a/lib/creature-symbol-factory.tsx
+++ b/lib/creature-symbol-factory.tsx
@@ -1,0 +1,143 @@
+import React from "react";
+import {
+  AttachedCreatureSymbol,
+  CreatureSymbol,
+  NestedCreatureSymbol,
+} from "./creature-symbol";
+import { AttachmentPointType } from "./specs";
+import { SvgSymbolData } from "./svg-symbol";
+
+type AttachmentIndices = {
+  left?: boolean;
+  right?: boolean;
+};
+
+type AttachmentChildren = JSX.Element | JSX.Element[];
+
+type SimpleCreatureSymbolProps = AttachmentIndices & {
+  nestInside?: boolean;
+  children?: AttachmentChildren;
+  attachTo?: AttachmentPointType;
+  indices?: number[];
+};
+
+function getAttachmentIndices(ai: AttachmentIndices): number[] {
+  const result: number[] = [];
+
+  if (ai.left) {
+    result.push(0);
+  }
+  if (ai.right) {
+    result.push(1);
+  }
+  if (result.length === 0) {
+    result.push(0);
+  }
+  return result;
+}
+
+type SplitCreatureSymbolChildren = {
+  attachments: JSX.Element[];
+  nests: JSX.Element[];
+};
+
+function splitCreatureSymbolChildren(
+  children?: AttachmentChildren
+): SplitCreatureSymbolChildren {
+  const result: SplitCreatureSymbolChildren = {
+    attachments: [],
+    nests: [],
+  };
+  if (!children) return result;
+
+  React.Children.forEach(children, (child) => {
+    if (child.props.nestInside) {
+      result.nests.push(child);
+    } else {
+      result.attachments.push(child);
+    }
+  });
+
+  return result;
+}
+
+type SimpleCreatureSymbolFC = React.FC<SimpleCreatureSymbolProps> & {
+  creatureSymbolData: SvgSymbolData;
+};
+
+/**
+ * Create a factory that can be used to return React components to
+ * render a `<CreatureSymbol>`.
+ */
+export function createCreatureSymbolFactory(
+  getSymbol: (name: string) => SvgSymbolData
+) {
+  /**
+   * Returns a React component that renders a `<CreatureSymbol>`, using the symbol
+   * with the given name as its default data.
+   */
+  return function createCreatureSymbol(
+    name: string
+  ): React.FC<SimpleCreatureSymbolProps> {
+    const data = getSymbol(name);
+    const Component: SimpleCreatureSymbolFC = (props) => {
+      const symbol = getCreatureSymbol(data, props);
+      return <CreatureSymbol {...symbol} />;
+    };
+    Component.creatureSymbolData = data;
+    return Component;
+  };
+}
+
+function isSimpleCreatureSymbolFC(fn: any): fn is SimpleCreatureSymbolFC {
+  return !!fn.creatureSymbolData;
+}
+
+function extractNestedCreatureSymbol(el: JSX.Element): NestedCreatureSymbol {
+  const base = extractCreatureSymbolFromElement(el);
+  const props: SimpleCreatureSymbolProps = el.props;
+  const indices = props.indices || getAttachmentIndices(props);
+  const result: NestedCreatureSymbol = {
+    ...base,
+    indices,
+  };
+  return result;
+}
+
+function extractAttachedCreatureSymbol(
+  el: JSX.Element
+): AttachedCreatureSymbol {
+  const base = extractNestedCreatureSymbol(el);
+  const props: SimpleCreatureSymbolProps = el.props;
+  const { attachTo } = props;
+  if (!attachTo) {
+    throw new Error("Expected attachment to have `attachTo` prop!");
+  }
+  const result: AttachedCreatureSymbol = {
+    ...base,
+    attachTo,
+  };
+  return result;
+}
+
+function getCreatureSymbol(
+  data: SvgSymbolData,
+  props: SimpleCreatureSymbolProps
+): CreatureSymbol {
+  const { attachments, nests } = splitCreatureSymbolChildren(props.children);
+  const result: CreatureSymbol = {
+    data,
+    attachments: attachments.map(extractAttachedCreatureSymbol),
+    nests: nests.map(extractNestedCreatureSymbol),
+  };
+  return result;
+}
+
+export function extractCreatureSymbolFromElement(
+  el: JSX.Element
+): CreatureSymbol {
+  if (isSimpleCreatureSymbolFC(el.type)) {
+    return getCreatureSymbol(el.type.creatureSymbolData, el.props);
+  }
+  throw new Error("Found unknown component type!");
+}

--- a/lib/creature-symbol.tsx
+++ b/lib/creature-symbol.tsx
@@ -1,8 +1,8 @@
 import React, { useContext } from "react";
-import { getAttachmentTransforms } from "./attach";
-import { scalePointXY, subtractPoints } from "./point";
 import { BBox, Point } from "../vendor/bezier-js";
+import { getAttachmentTransforms } from "./attach";
 import { getBoundingBoxCenter, uniformlyScaleToFit } from "./bounding-box";
+import { scalePointXY, subtractPoints } from "./point";
 import { AttachmentPointType, PointWithNormal } from "./specs";
 import {
   createSvgSymbolContext,
@@ -54,8 +54,6 @@ function safeGetAttachmentPoint(
   return null;
 }
 
-type AttachmentChildren = JSX.Element | JSX.Element[];
-
 export type CreatureContextType = SvgSymbolContext & {
   attachmentScale: number;
   parent: SvgSymbolData | null;
@@ -67,221 +65,29 @@ export const CreatureContext = React.createContext<CreatureContextType>({
   parent: null,
 });
 
-type AttachmentIndices = {
-  left?: boolean;
-  right?: boolean;
-};
-
-export type AttachedNormalizedCreatureSymbol = NormalizedCreatureSymbol & {
+export type AttachedCreatureSymbol = CreatureSymbol & {
   attachTo: AttachmentPointType;
   indices: number[];
 };
 
-export type NestedNormalizedCreatureSymbol = NormalizedCreatureSymbol & {
+export type NestedCreatureSymbol = CreatureSymbol & {
   indices: number[];
 };
 
-export type NormalizedCreatureSymbol = {
+export type CreatureSymbol = {
   data: SvgSymbolData;
-  attachments: AttachedNormalizedCreatureSymbol[];
-  nesting: NestedNormalizedCreatureSymbol[];
+  attachments: AttachedCreatureSymbol[];
+  nests: NestedCreatureSymbol[];
 };
 
-export type CreatureSymbolProps = AttachmentIndices & {
-  data: SvgSymbolData;
-  nestInside?: boolean;
-  children?: AttachmentChildren;
-  attachTo?: AttachmentPointType;
-  indices?: number[];
-};
+export type CreatureSymbolProps = CreatureSymbol;
 
-function getAttachmentIndices(ai: AttachmentIndices): number[] {
-  const result: number[] = [];
-
-  if (ai.left) {
-    result.push(0);
-  }
-  if (ai.right) {
-    result.push(1);
-  }
-  if (result.length === 0) {
-    result.push(0);
-  }
-  return result;
-}
-
-type SplitCreatureSymbolChildren = {
-  attachments: JSX.Element[];
-  nests: JSX.Element[];
-};
-
-function splitCreatureSymbolChildren(
-  children?: AttachmentChildren
-): SplitCreatureSymbolChildren {
-  const result: SplitCreatureSymbolChildren = {
-    attachments: [],
-    nests: [],
-  };
-  if (!children) return result;
-
-  React.Children.forEach(children, (child) => {
-    if (child.props.nestInside) {
-      result.nests.push(child);
-    } else {
-      result.attachments.push(child);
-    }
-  });
-
-  return result;
-}
-
-type ChildCreatureSymbolProps = {
-  symbol: JSX.Element;
-  data: SvgSymbolData;
+type NestedCreatureSymbolProps = NestedCreatureSymbol & {
   parent: SvgSymbolData;
-  indices: number[];
 };
 
-const NestedCreatureSymbol: React.FC<ChildCreatureSymbolProps> = ({
-  symbol,
-  data,
-  parent,
-  indices,
-}) => {
-  const children: JSX.Element[] = [];
-
-  for (let nestIndex of indices) {
-    const parentNest = (parent.specs?.nesting ?? [])[nestIndex];
-    if (!parentNest) {
-      console.log(
-        `Parent symbol ${parent.name} has no nesting index ${nestIndex}.`
-      );
-      continue;
-    }
-    const t = getNestingTransforms(parentNest, data.bbox);
-    children.push(
-      <AttachmentTransform
-        key={nestIndex}
-        transformOrigin={t.transformOrigin}
-        translate={t.translation}
-        scale={t.scaling}
-        rotate={0}
-      >
-        <g
-          data-attach-parent={parent.name}
-          data-attach-type="nesting"
-          data-attach-index={nestIndex}
-        >
-          {symbol}
-        </g>
-      </AttachmentTransform>
-    );
-  }
-
-  return <>{children}</>;
-};
-
-const AttachedCreatureSymbol: React.FC<
-  ChildCreatureSymbolProps & {
-    attachTo: AttachmentPointType;
-  }
-> = ({ symbol, data, parent, indices, attachTo }) => {
-  const ctx = useContext(CreatureContext);
-  const children: JSX.Element[] = [];
-
-  for (let attachIndex of indices) {
-    const parentAp = safeGetAttachmentPoint(parent, attachTo, attachIndex);
-    const ourAp = safeGetAttachmentPoint(data, "anchor");
-
-    if (!parentAp || !ourAp) {
-      continue;
-    }
-
-    // If we're attaching something oriented towards the left, horizontally flip
-    // the attachment image.
-    let xFlip = parentAp.normal.x < 0 ? -1 : 1;
-
-    // Er, things look weird if we don't inverse the flip logic for
-    // the downward-facing attachments, like legs...
-    if (parentAp.normal.y > 0) {
-      xFlip *= -1;
-    }
-
-    const t = getAttachmentTransforms(parentAp, {
-      point: ourAp.point,
-      normal: scalePointXY(ourAp.normal, xFlip, 1),
-    });
-
-    children.push(
-      <AttachmentTransform
-        key={attachIndex}
-        transformOrigin={ourAp.point}
-        translate={t.translation}
-        scale={{ x: ctx.attachmentScale * xFlip, y: ctx.attachmentScale }}
-        rotate={xFlip * t.rotation}
-      >
-        <g
-          data-attach-parent={parent.name}
-          data-attach-type={attachTo}
-          data-attach-index={attachIndex}
-        >
-          {symbol}
-        </g>
-      </AttachmentTransform>
-    );
-  }
-
-  return <>{children}</>;
-};
-
-export const CreatureSymbol: React.FC<CreatureSymbolProps> = (props) => {
-  const ctx = useContext(CreatureContext);
-  const { data, attachTo, nestInside } = props;
-  const childCtx: CreatureContextType = { ...ctx, parent: data };
-  const { nests, attachments } = splitCreatureSymbolChildren(props.children);
-
-  // The attachments should be before our symbol in the DOM so they
-  // appear behind our symbol, while anything nested within our symbol
-  // should be after our symbol so they appear in front of it.
-  const symbol = (
-    <>
-      {attachments.length && (
-        <CreatureContext.Provider value={childCtx}>
-          {attachments}
-        </CreatureContext.Provider>
-      )}
-      <SvgSymbolContent data={data} {...ctx} />
-      {nests.length && (
-        <CreatureContext.Provider value={childCtx}>
-          {nests}
-        </CreatureContext.Provider>
-      )}
-    </>
-  );
-
-  if (!(attachTo || nestInside)) {
-    return symbol;
-  }
-
-  const parent = ctx.parent;
-  if (!parent) {
-    throw new Error(
-      `Cannot attach/nest ${props.data.name} because it has no parent!`
-    );
-  }
-
-  const childProps: ChildCreatureSymbolProps = {
-    parent,
-    symbol,
-    data,
-    indices: props.indices || getAttachmentIndices(props),
-  };
-
-  if (attachTo) {
-    return <AttachedCreatureSymbol {...childProps} attachTo={attachTo} />;
-  }
-
-  return <NestedCreatureSymbol {...childProps} />;
+type AttachedCreatureSymbolProps = AttachedCreatureSymbol & {
+  parent: SvgSymbolData;
 };
 
 function getNestingTransforms(parent: BBox, child: BBox) {
@@ -326,86 +132,125 @@ const AttachmentTransform: React.FC<AttachmentTransformProps> = (props) => (
   </g>
 );
 
-export type SimpleCreatureSymbolProps = Omit<CreatureSymbolProps, "data">;
+const AttachedCreatureSymbol: React.FC<AttachedCreatureSymbolProps> = ({
+  indices,
+  parent,
+  attachTo,
+  data,
+  ...props
+}) => {
+  const ctx = useContext(CreatureContext);
+  const children: JSX.Element[] = [];
 
-/**
- * Create a factory that can be used to return React components to
- * render a `<CreatureSymbol>`.
- */
-export function createCreatureSymbolFactory(
-  getSymbol: (name: string) => SvgSymbolData
-) {
-  /**
-   * Returns a React component that renders a `<CreatureSymbol>`, using the symbol
-   * with the given name as its default data.
-   */
-  return function createCreatureSymbol(
-    name: string
-  ): React.FC<SimpleCreatureSymbolProps> {
-    const data = getSymbol(name);
-    const Component: React.FC<SimpleCreatureSymbolProps> = (props) => (
-      <CreatureSymbol data={data} {...props} />
+  for (let attachIndex of indices) {
+    const parentAp = safeGetAttachmentPoint(parent, attachTo, attachIndex);
+    const ourAp = safeGetAttachmentPoint(data, "anchor");
+
+    if (!parentAp || !ourAp) {
+      continue;
+    }
+
+    // If we're attaching something oriented towards the left, horizontally flip
+    // the attachment image.
+    let xFlip = parentAp.normal.x < 0 ? -1 : 1;
+
+    // Er, things look weird if we don't inverse the flip logic for
+    // the downward-facing attachments, like legs...
+    if (parentAp.normal.y > 0) {
+      xFlip *= -1;
+    }
+
+    const t = getAttachmentTransforms(parentAp, {
+      point: ourAp.point,
+      normal: scalePointXY(ourAp.normal, xFlip, 1),
+    });
+
+    children.push(
+      <AttachmentTransform
+        key={attachIndex}
+        transformOrigin={ourAp.point}
+        translate={t.translation}
+        scale={{ x: ctx.attachmentScale * xFlip, y: ctx.attachmentScale }}
+        rotate={xFlip * t.rotation}
+      >
+        <g
+          data-attach-parent={parent.name}
+          data-attach-type={attachTo}
+          data-attach-index={attachIndex}
+        >
+          <CreatureSymbol data={data} {...props} />
+        </g>
+      </AttachmentTransform>
     );
-    (Component as any)._isCreatedCreatureSymbol = true;
-    Component.defaultProps = {
-      data,
-    };
-    return Component;
-  };
-}
-
-function normalizeNestedCreatureSymbol(
-  el: JSX.Element
-): NestedNormalizedCreatureSymbol {
-  const base = normalizeCreatureSymbol(el);
-  const props: SimpleCreatureSymbolProps = el.props;
-  const indices = props.indices || getAttachmentIndices(props);
-  const result: NestedNormalizedCreatureSymbol = {
-    ...base,
-    indices,
-  };
-  return result;
-}
-
-function normalizeAttachedCreatureSymbol(
-  el: JSX.Element
-): AttachedNormalizedCreatureSymbol {
-  const base = normalizeNestedCreatureSymbol(el);
-  const props: SimpleCreatureSymbolProps = el.props;
-  const { attachTo } = props;
-  if (!attachTo) {
-    throw new Error("Expected attachment to have `attachTo` prop!");
-  }
-  const result: AttachedNormalizedCreatureSymbol = {
-    ...base,
-    attachTo,
-  };
-  return result;
-}
-
-export function normalizeCreatureSymbol(
-  el: JSX.Element
-): NormalizedCreatureSymbol {
-  let data: SvgSymbolData;
-  let props: SimpleCreatureSymbolProps;
-
-  if (el.type === CreatureSymbol) {
-    const eProps: CreatureSymbolProps = el.props;
-    data = eProps.data;
-    props = eProps;
-  } else if (el.type._createdCreatureSymbolData) {
-    const eProps: SimpleCreatureSymbolProps = el.props;
-    data = el.type._createdCreatureSymbolData;
-    props = eProps;
-  } else {
-    throw new Error("Found unknown component type!");
   }
 
-  const { attachments, nests } = splitCreatureSymbolChildren(props.children);
-  const result: NormalizedCreatureSymbol = {
-    data,
-    attachments: attachments.map(normalizeAttachedCreatureSymbol),
-    nesting: nests.map(normalizeNestedCreatureSymbol),
-  };
-  return result;
-}
+  return <>{children}</>;
+};
+
+const NestedCreatureSymbol: React.FC<NestedCreatureSymbolProps> = ({
+  indices,
+  parent,
+  data,
+  ...props
+}) => {
+  const children: JSX.Element[] = [];
+
+  for (let nestIndex of indices) {
+    const parentNest = (parent.specs?.nesting ?? [])[nestIndex];
+    if (!parentNest) {
+      console.log(
+        `Parent symbol ${parent.name} has no nesting index ${nestIndex}.`
+      );
+      continue;
+    }
+    const t = getNestingTransforms(parentNest, data.bbox);
+    children.push(
+      <AttachmentTransform
+        key={nestIndex}
+        transformOrigin={t.transformOrigin}
+        translate={t.translation}
+        scale={t.scaling}
+        rotate={0}
+      >
+        <g
+          data-attach-parent={parent.name}
+          data-attach-type="nesting"
+          data-attach-index={nestIndex}
+        >
+          <CreatureSymbol data={data} {...props} />
+        </g>
+      </AttachmentTransform>
+    );
+  }
+
+  return <>{children}</>;
+};
+
+export const CreatureSymbol: React.FC<CreatureSymbolProps> = (props) => {
+  const ctx = useContext(CreatureContext);
+  const { data, attachments, nests } = props;
+  const childCtx: CreatureContextType = { ...ctx, parent: data };
+
+  // The attachments should be before our symbol in the DOM so they
+  // appear behind our symbol, while anything nested within our symbol
+  // should be after our symbol so they appear in front of it.
+  return (
+    <>
+      {attachments.length && (
+        <CreatureContext.Provider value={childCtx}>
+          {attachments.map((a, i) => (
+            <AttachedCreatureSymbol key={i} {...a} parent={data} />
+          ))}
+        </CreatureContext.Provider>
+      )}
+      <SvgSymbolContent data={data} {...ctx} />
+      {nests.length && (
+        <CreatureContext.Provider value={childCtx}>
+          {nests.map((n, i) => (
+            <NestedCreatureSymbol key={i} {...n} parent={data} />
+          ))}
+        </CreatureContext.Provider>
+      )}
+    </>
+  );
+};

--- a/lib/pages/creature-page.tsx
+++ b/lib/pages/creature-page.tsx
@@ -9,10 +9,11 @@ import { range } from "../util";
 import { AutoSizingSvg } from "../auto-sizing-svg";
 import { exportSvg } from "../export-svg";
 import {
+  createCreatureSymbolFactory,
+  normalizeCreatureSymbol,
   CreatureContext,
   CreatureContextType,
   CreatureSymbol,
-  CreatureSymbolProps,
 } from "../creature-symbol";
 import { HoverDebugHelper } from "../hover-debug-helper";
 
@@ -105,51 +106,27 @@ function getSymbolWithAttachments(
   return <CreatureSymbol data={root} children={children} />;
 }
 
-/**
- * A creature symbol that comes with default (but overrideable) symbol data.
- * This makes it easy to use the symbol in JSX, but also easy to dynamically
- * replace the symbol with a different one.
- */
-type CreatureSymbolWithDefaultProps = Omit<CreatureSymbolProps, "data"> & {
-  data?: SvgSymbolData;
-};
+const symbol = createCreatureSymbolFactory(getSymbol);
 
-/**
- * Returns a React component that renders a `<CreatureSymbol>`, using the symbol
- * with the given name as its default data.
- */
-function createCreatureSymbol(
-  name: string
-): React.FC<CreatureSymbolWithDefaultProps> {
-  const data = getSymbol(name);
-  const Component: React.FC<CreatureSymbolWithDefaultProps> = (props) => (
-    <CreatureSymbol data={props.data || data} {...props} />
-  );
-  Component.defaultProps = {
-    data,
-  };
-  return Component;
-}
+const Eye = symbol("eye");
 
-const Eye = createCreatureSymbol("eye");
+const Hand = symbol("hand");
 
-const Hand = createCreatureSymbol("hand");
+const Arm = symbol("arm");
 
-const Arm = createCreatureSymbol("arm");
+const Antler = symbol("antler");
 
-const Antler = createCreatureSymbol("antler");
+const Crown = symbol("crown");
 
-const Crown = createCreatureSymbol("crown");
+const Wing = symbol("wing");
 
-const Wing = createCreatureSymbol("wing");
+const MuscleArm = symbol("muscle_arm");
 
-const MuscleArm = createCreatureSymbol("muscle_arm");
+const Leg = symbol("leg");
 
-const Leg = createCreatureSymbol("leg");
+const Tail = symbol("tail");
 
-const Tail = createCreatureSymbol("tail");
-
-const Lightning = createCreatureSymbol("lightning");
+const Lightning = symbol("lightning");
 
 const EYE_CREATURE = (
   <Eye>
@@ -178,6 +155,8 @@ const EYE_CREATURE = (
  * sure the final creature structure is fully valid.
  */
 function randomlyReplaceParts(rng: Random, creature: JSX.Element): JSX.Element {
+  const normalized = normalizeCreatureSymbol(creature);
+
   return React.cloneElement<CreatureSymbolWithDefaultProps>(creature, {
     data: rng.choice(SvgVocabulary),
     children: React.Children.map(creature.props.children, (child, i) => {

--- a/lib/pages/creature-page.tsx
+++ b/lib/pages/creature-page.tsx
@@ -122,7 +122,13 @@ function createCreatureSymbol(
   name: string
 ): React.FC<CreatureSymbolWithDefaultProps> {
   const data = getSymbol(name);
-  return (props) => <CreatureSymbol data={props.data || data} {...props} />;
+  const Component: React.FC<CreatureSymbolWithDefaultProps> = (props) => (
+    <CreatureSymbol data={props.data || data} {...props} />
+  );
+  Component.defaultProps = {
+    data,
+  };
+  return Component;
 }
 
 const Eye = createCreatureSymbol("eye");


### PR DESCRIPTION
This refactors `creature-symbol.tsx` so that it doesn't have to rely on awkwardly introspecting `JSX.Element` instances to do its job.  Now all of that mumbo-jumbo, which is only really useful for when we want to manually construct symbols like the eye creature, is encapsulated in `creature-symbol-factory.tsx`.