### PR TITLE
Add checkbox for randomly inverting some symbols.

### DIFF
--- a/lib/pages/creature-page.tsx
+++ b/lib/pages/creature-page.tsx
@@ -93,14 +93,17 @@ function getNestingChildren(
  */
 function getSymbolWithAttachments(
   numAttachmentKinds: number,
-  rng: Random
+  { rng, randomlyInvert: randomlyInvertSymbols }: CreatureGeneratorOptions
 ): CreatureSymbol {
   const root = rng.choice(ROOT_SYMBOLS);
+  const randomlyInvertRng = rng.clone();
+  const shouldInvert = () =>
+    randomlyInvertSymbols ? randomlyInvertRng.bool() : false;
   const result: CreatureSymbol = {
     data: root,
     attachments: [],
     nests: getNestingChildren(root, rng, true),
-    invertColors: false,
+    invertColors: shouldInvert(),
   };
   if (root.specs) {
     const attachmentKinds = rng.uniqueChoices(
@@ -118,7 +121,7 @@ function getSymbolWithAttachments(
         indices,
         attachments: [],
         nests: getNestingChildren(attachment, rng),
-        invertColors: false,
+        invertColors: shouldInvert(),
       });
     }
   }
@@ -188,7 +191,12 @@ function randomlyReplaceParts<T extends CreatureSymbol>(
   return result;
 }
 
-type CreatureGenerator = (rng: Random) => CreatureSymbol;
+type CreatureGeneratorOptions = {
+  rng: Random;
+  randomlyInvert: boolean;
+};
+
+type CreatureGenerator = (options: CreatureGeneratorOptions) => CreatureSymbol;
 
 /**
  * Each index of this array represents the algorithm we use to
@@ -199,7 +207,7 @@ type CreatureGenerator = (rng: Random) => CreatureSymbol;
  */
 const COMPLEXITY_LEVEL_GENERATORS: CreatureGenerator[] = [
   ...range(5).map((i) => getSymbolWithAttachments.bind(null, i)),
-  (rng) => randomlyReplaceParts(rng, EYE_CREATURE_SYMBOL),
+  ({ rng }) => randomlyReplaceParts(rng, EYE_CREATURE_SYMBOL),
 ];
 
 const MAX_COMPLEXITY_LEVEL = COMPLEXITY_LEVEL_GENERATORS.length - 1;
@@ -231,7 +239,10 @@ export const CreaturePage: React.FC<{}> = () => {
   const creature =
     randomSeed === null
       ? EYE_CREATURE_SYMBOL
-      : COMPLEXITY_LEVEL_GENERATORS[complexity](new Random(randomSeed));
+      : COMPLEXITY_LEVEL_GENERATORS[complexity]({
+          rng: new Random(randomSeed),
+          randomlyInvert,
+        });
   const handleSvgExport = () =>
     exportSvg(getDownloadFilename(randomSeed), svgRef);
   const isBonkers = complexity === MAX_COMPLEXITY_LEVEL;

--- a/lib/pages/creature-page.tsx
+++ b/lib/pages/creature-page.tsx
@@ -218,6 +218,7 @@ export const CreaturePage: React.FC<{}> = () => {
   const svgRef = useRef<SVGSVGElement>(null);
   const [bgColor, setBgColor] = useState(DEFAULT_BG_COLOR);
   const [randomSeed, setRandomSeed] = useState<number | null>(null);
+  const [randomlyInvert, setRandomlyInvert] = useState(false);
   const [symbolCtx, setSymbolCtx] = useState(createSvgSymbolContext());
   const [complexity, setComplexity] = useState(MAX_COMPLEXITY_LEVEL);
   const defaultCtx = useContext(CreatureContext);
@@ -233,6 +234,7 @@ export const CreaturePage: React.FC<{}> = () => {
       : COMPLEXITY_LEVEL_GENERATORS[complexity](new Random(randomSeed));
   const handleSvgExport = () =>
     exportSvg(getDownloadFilename(randomSeed), svgRef);
+  const isBonkers = complexity === MAX_COMPLEXITY_LEVEL;
 
   return (
     <>
@@ -258,8 +260,20 @@ export const CreaturePage: React.FC<{}> = () => {
             newRandomSeed();
           }}
         />{" "}
-        {complexity === MAX_COMPLEXITY_LEVEL ? "bonkers" : complexity}
+        {isBonkers ? "bonkers" : complexity}
       </p>
+      {!isBonkers && (
+        <p>
+          <label>
+            <input
+              type="checkbox"
+              checked={randomlyInvert}
+              onChange={(e) => setRandomlyInvert(e.target.checked)}
+            />
+            Randomly invert symbols
+          </label>
+        </p>
+      )}
       <p>
         <button accessKey="r" onClick={newRandomSeed}>
           <u>R</u>andomize!

--- a/lib/random.ts
+++ b/lib/random.ts
@@ -25,6 +25,13 @@ export class Random {
   }
 
   /**
+   * Create an exact replica of this instance.
+   */
+  clone(): Random {
+    return new Random(this.latestSeed, this.params);
+  }
+
+  /**
    * Return a random number that is greater than or equal to zero, and less
    * than one.
    */
@@ -33,6 +40,13 @@ export class Random {
       (this.params.multiplier * this.latestSeed + this.params.increment) %
       this.params.modulus;
     return this.latestSeed / this.params.modulus;
+  }
+
+  /**
+   * Return a random boolean with the given probability of being true.
+   */
+  bool(trueProbability: number = 0.5): boolean {
+    return this.next() < trueProbability;
   }
 
   /**


### PR DESCRIPTION
This fixes #39 by adding a "Randomly invert symbols" checkbox.

If the inversion is undesirable, disabling it will keep the existing creature but remove the inversion.

Note that this checkbox is only displayed when the creature complexity isn't bonkers.

> ![image](https://user-images.githubusercontent.com/124687/110226216-51b91400-7ebb-11eb-89d8-660ebe0551b3.png)
