### PR TITLE
Add a very basic Mandala page.

### DIFF
--- a/lib/browser-main.tsx
+++ b/lib/browser-main.tsx
@@ -3,11 +3,13 @@ import ReactDOM from "react-dom";
 import { WavesPage } from "./pages/waves-page";
 import { VocabularyPage } from "./pages/vocabulary-page";
 import { CreaturePage } from "./pages/creature-page";
+import { MandalaPage } from "./pages/mandala-page";
 
 const Pages = {
   vocabulary: VocabularyPage,
   creature: CreaturePage,
   waves: WavesPage,
+  mandala: MandalaPage,
 };
 
 type PageName = keyof typeof Pages;

--- a/lib/creature-symbol.tsx
+++ b/lib/creature-symbol.tsx
@@ -14,6 +14,7 @@ import {
 import {
   svgRotate,
   svgScale,
+  svgTransformOrigin,
   SvgTransforms,
   svgTranslate,
 } from "./svg-transform";
@@ -120,16 +121,10 @@ const AttachmentTransform: React.FC<AttachmentTransformProps> = (props) => (
   <SvgTransforms
     transforms={[
       svgTranslate(props.translate),
-      /**
-       * We originally used "transform-origin" here but that's not currently
-       * supported by Safari. Instead, we'll set the origin of our symbol to
-       * the transform origin, do the transform, and then move our origin back to
-       * the original origin, which is equivalent to setting "transform-origin".
-       **/
-      svgTranslate(props.transformOrigin),
-      svgScale(props.scale),
-      svgRotate(props.rotate),
-      svgTranslate(reversePoint(props.transformOrigin)),
+      svgTransformOrigin(props.transformOrigin, [
+        svgScale(props.scale),
+        svgRotate(props.rotate),
+      ]),
     ]}
   >
     {props.children}

--- a/lib/creature-symbol.tsx
+++ b/lib/creature-symbol.tsx
@@ -2,7 +2,7 @@ import React, { useContext } from "react";
 import { BBox, Point } from "../vendor/bezier-js";
 import { getAttachmentTransforms } from "./attach";
 import { getBoundingBoxCenter, uniformlyScaleToFit } from "./bounding-box";
-import { reversePoint, scalePointXY, subtractPoints } from "./point";
+import { scalePointXY, subtractPoints } from "./point";
 import { AttachmentPointType, PointWithNormal } from "./specs";
 import {
   createSvgSymbolContext,

--- a/lib/pages/creature-page.tsx
+++ b/lib/pages/creature-page.tsx
@@ -1,5 +1,5 @@
 import React, { useContext, useRef, useState } from "react";
-import { SvgVocabulary } from "../svg-vocabulary";
+import { getSvgSymbol, SvgVocabulary } from "../svg-vocabulary";
 import { createSvgSymbolContext, SvgSymbolData } from "../svg-symbol";
 import {
   AttachmentPointType,
@@ -25,13 +25,6 @@ import {
 import { HoverDebugHelper } from "../hover-debug-helper";
 
 const DEFAULT_BG_COLOR = "#858585";
-
-/**
- * Mapping from symbol names to symbol data, for quick and easy access.
- */
-const SYMBOL_MAP = new Map(
-  SvgVocabulary.map((symbol) => [symbol.name, symbol])
-);
 
 /** Symbols that can be the "root" (i.e., main body) of a creature. */
 const ROOT_SYMBOLS = SvgVocabulary.filter(
@@ -81,18 +74,6 @@ const NESTED_SYMBOLS = SvgVocabulary.filter(
   (data) =>
     data.meta?.always_nest !== true && data.meta?.never_be_nested !== true
 );
-
-/**
- * Returns the data for the given symbol, throwing an error
- * if it doesn't exist.
- */
-function getSymbol(name: string): SvgSymbolData {
-  const symbol = SYMBOL_MAP.get(name);
-  if (!symbol) {
-    throw new Error(`Unable to find the symbol "${name}"!`);
-  }
-  return symbol;
-}
 
 /**
  * Given a parent symbol, return an array of random children to be nested within
@@ -165,7 +146,7 @@ function getSymbolWithAttachments(
   return result;
 }
 
-const symbol = createCreatureSymbolFactory(getSymbol);
+const symbol = createCreatureSymbolFactory(getSvgSymbol);
 
 const Eye = symbol("eye");
 

--- a/lib/pages/mandala-page.tsx
+++ b/lib/pages/mandala-page.tsx
@@ -1,6 +1,7 @@
-import React from "react";
+import React, { useState } from "react";
 import { AutoSizingSvg } from "../auto-sizing-svg";
 import { getBoundingBoxCenter } from "../bounding-box";
+import { HoverDebugHelper } from "../hover-debug-helper";
 import { reversePoint } from "../point";
 import {
   createSvgSymbolContext,
@@ -15,6 +16,7 @@ import {
   svgTranslate,
 } from "../svg-transform";
 import { getSvgSymbol } from "../svg-vocabulary";
+import { SymbolContextWidget } from "../symbol-context-widget";
 import { range } from "../util";
 
 const EYE = getSvgSymbol("eye");
@@ -51,16 +53,24 @@ const MandalaCircle: React.FC<
 };
 
 export const MandalaPage: React.FC<{}> = () => {
-  const ctx = createSvgSymbolContext();
+  const [symbolCtx, setSymbolCtx] = useState(createSvgSymbolContext());
 
   return (
     <>
       <h1>Mandala!</h1>
-      <AutoSizingSvg padding={20}>
-        <SvgTransforms transforms={[svgScale(0.5)]}>
-          <MandalaCircle data={EYE} radius={400} numSymbols={6} {...ctx} />
-        </SvgTransforms>
-      </AutoSizingSvg>
+      <SymbolContextWidget ctx={symbolCtx} onChange={setSymbolCtx} />
+      <HoverDebugHelper>
+        <AutoSizingSvg padding={20}>
+          <SvgTransforms transforms={[svgScale(0.5)]}>
+            <MandalaCircle
+              data={EYE}
+              radius={400}
+              numSymbols={6}
+              {...symbolCtx}
+            />
+          </SvgTransforms>
+        </AutoSizingSvg>
+      </HoverDebugHelper>
     </>
   );
 };

--- a/lib/pages/mandala-page.tsx
+++ b/lib/pages/mandala-page.tsx
@@ -1,18 +1,65 @@
 import React from "react";
 import { AutoSizingSvg } from "../auto-sizing-svg";
-import { createCreatureSymbolFactory } from "../creature-symbol-factory";
+import { getBoundingBoxCenter } from "../bounding-box";
+import { reversePoint } from "../point";
+import {
+  createSvgSymbolContext,
+  SvgSymbolContent,
+  SvgSymbolContext,
+  SvgSymbolData,
+} from "../svg-symbol";
+import {
+  svgRotate,
+  svgScale,
+  SvgTransforms,
+  svgTranslate,
+} from "../svg-transform";
 import { getSvgSymbol } from "../svg-vocabulary";
+import { range } from "../util";
 
-const symbol = createCreatureSymbolFactory(getSvgSymbol);
+const EYE = getSvgSymbol("eye");
 
-const Eye = symbol("eye");
+const MandalaCircle: React.FC<
+  {
+    data: SvgSymbolData;
+    radius: number;
+    numSymbols: number;
+  } & SvgSymbolContext
+> = (props) => {
+  const center = getBoundingBoxCenter(props.data.bbox);
+  const degreesPerItem = 360 / props.numSymbols;
+  const symbol = (
+    <SvgTransforms
+      transforms={[
+        svgTranslate({ x: props.radius, y: 0 }),
+        svgTranslate(reversePoint(center)),
+      ]}
+    >
+      <SvgSymbolContent {...props} />
+    </SvgTransforms>
+  );
+
+  const symbols = range(props.numSymbols).map((i) => (
+    <SvgTransforms
+      key={i}
+      transforms={[svgRotate(degreesPerItem * i)]}
+      children={symbol}
+    />
+  ));
+
+  return <>{symbols}</>;
+};
 
 export const MandalaPage: React.FC<{}> = () => {
+  const ctx = createSvgSymbolContext();
+
   return (
     <>
       <h1>Mandala!</h1>
       <AutoSizingSvg padding={20}>
-        <Eye />
+        <SvgTransforms transforms={[svgScale(0.5)]}>
+          <MandalaCircle data={EYE} radius={400} numSymbols={6} {...ctx} />
+        </SvgTransforms>
       </AutoSizingSvg>
     </>
   );

--- a/lib/pages/mandala-page.tsx
+++ b/lib/pages/mandala-page.tsx
@@ -1,0 +1,9 @@
+import React from "react";
+
+export const MandalaPage: React.FC<{}> = () => {
+  return (
+    <>
+      <h1>Mandala!</h1>
+    </>
+  );
+};

--- a/lib/pages/mandala-page.tsx
+++ b/lib/pages/mandala-page.tsx
@@ -1,9 +1,19 @@
 import React from "react";
+import { AutoSizingSvg } from "../auto-sizing-svg";
+import { createCreatureSymbolFactory } from "../creature-symbol-factory";
+import { getSvgSymbol } from "../svg-vocabulary";
+
+const symbol = createCreatureSymbolFactory(getSvgSymbol);
+
+const Eye = symbol("eye");
 
 export const MandalaPage: React.FC<{}> = () => {
   return (
     <>
       <h1>Mandala!</h1>
+      <AutoSizingSvg padding={20}>
+        <Eye />
+      </AutoSizingSvg>
     </>
   );
 };

--- a/lib/point.ts
+++ b/lib/point.ts
@@ -1,5 +1,10 @@
 import { Point } from "../vendor/bezier-js";
 
+/** Return the "reverse" of the given point/vector, i.e. scale it by -1. */
+export function reversePoint(p: Point): Point {
+  return { x: -p.x, y: -p.y };
+}
+
 export function scalePointXY(p: Point, xScale: number, yScale: number): Point {
   return {
     x: p.x * xScale,

--- a/lib/svg-transform.tsx
+++ b/lib/svg-transform.tsx
@@ -1,0 +1,52 @@
+import React from "react";
+import { Point } from "../vendor/bezier-js";
+
+type SvgTransform =
+  | {
+      kind: "translate";
+      amount: Point;
+    }
+  | {
+      kind: "rotate";
+      degrees: number;
+    }
+  | {
+      kind: "scale";
+      amount: Point;
+    };
+
+function getSvgCodeForTransform(t: SvgTransform): string {
+  switch (t.kind) {
+    case "translate":
+      return `translate(${t.amount.x} ${t.amount.y})`;
+
+    case "scale":
+      return `scale(${t.amount.x} ${t.amount.y})`;
+
+    case "rotate":
+      return `rotate(${t.degrees})`;
+  }
+}
+
+export function svgTranslate(amount: Point): SvgTransform {
+  return { kind: "translate", amount };
+}
+
+export function svgScale(amount: Point): SvgTransform {
+  return { kind: "scale", amount };
+}
+
+export function svgRotate(degrees: number): SvgTransform {
+  return { kind: "rotate", degrees };
+}
+
+export const SvgTransforms: React.FC<{
+  transforms: SvgTransform[];
+  children: any;
+}> = ({ transforms, children }) => {
+  return (
+    <g transform={transforms.map(getSvgCodeForTransform).join(" ")}>
+      {children}
+    </g>
+  );
+};

--- a/lib/svg-transform.tsx
+++ b/lib/svg-transform.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { Point } from "../vendor/bezier-js";
+import { reversePoint } from "./point";
 
 type SvgTransform =
   | {
@@ -13,6 +14,11 @@ type SvgTransform =
   | {
       kind: "scale";
       amount: Point;
+    }
+  | {
+      kind: "transformOrigin";
+      amount: Point;
+      transforms: SvgTransform[];
     };
 
 function getSvgCodeForTransform(t: SvgTransform): string {
@@ -25,14 +31,45 @@ function getSvgCodeForTransform(t: SvgTransform): string {
 
     case "rotate":
       return `rotate(${t.degrees})`;
+
+    case "transformOrigin":
+      /**
+       * We originally used the SVG "transform-origin" attribute here but
+       * that's not currently supported by Safari. Instead, we'll set the origin
+       * of our SVG to the transform origin, do the transform, and then move our
+       * origin back to the original origin, which does the same thing.
+       **/
+      return getSvgCodeForTransforms([
+        svgTranslate(t.amount),
+        ...t.transforms,
+        svgTranslate(reversePoint(t.amount)),
+      ]);
   }
+}
+
+function getSvgCodeForTransforms(transforms: SvgTransform[]): string {
+  return transforms.map(getSvgCodeForTransform).join(" ");
+}
+
+/**
+ * Apply the given SVG transforms (e.g. rotate, scale)
+ * centered at the given origin point.
+ */
+export function svgTransformOrigin(
+  amount: Point,
+  transforms: SvgTransform[]
+): SvgTransform {
+  return { kind: "transformOrigin", amount, transforms };
 }
 
 export function svgTranslate(amount: Point): SvgTransform {
   return { kind: "translate", amount };
 }
 
-export function svgScale(amount: Point): SvgTransform {
+export function svgScale(amount: Point | number): SvgTransform {
+  if (typeof amount === "number") {
+    amount = { x: amount, y: amount };
+  }
   return { kind: "scale", amount };
 }
 
@@ -40,13 +77,15 @@ export function svgRotate(degrees: number): SvgTransform {
   return { kind: "rotate", degrees };
 }
 
+/**
+ * Creates a SVG `<g>` element with the given children and transforms.
+ *
+ * Like the SVG `transform` attribute, the transforms are applied in
+ * the *reverse* order that they are specified.
+ */
 export const SvgTransforms: React.FC<{
   transforms: SvgTransform[];
   children: any;
 }> = ({ transforms, children }) => {
-  return (
-    <g transform={transforms.map(getSvgCodeForTransform).join(" ")}>
-      {children}
-    </g>
-  );
+  return <g transform={getSvgCodeForTransforms(transforms)}>{children}</g>;
 };

--- a/lib/svg-vocabulary.ts
+++ b/lib/svg-vocabulary.ts
@@ -2,3 +2,22 @@ import type { SvgSymbolData } from "./svg-symbol";
 import _SvgVocabulary from "./_svg-vocabulary.json";
 
 export const SvgVocabulary: SvgSymbolData[] = _SvgVocabulary as any;
+
+/**
+ * Mapping from symbol names to symbol data, for quick and easy access.
+ */
+const SYMBOL_MAP = new Map(
+  SvgVocabulary.map((symbol) => [symbol.name, symbol])
+);
+
+/**
+ * Returns the data for the given symbol, throwing an error
+ * if it doesn't exist.
+ */
+export function getSvgSymbol(name: string): SvgSymbolData {
+  const symbol = SYMBOL_MAP.get(name);
+  if (!symbol) {
+    throw new Error(`Unable to find the symbol "${name}"!`);
+  }
+  return symbol;
+}


### PR DESCRIPTION
This adds an extremely simple Mandala page (for #24) with a single circle Mandala comprised of several eyes.  The symbol style is configurable, but parameters for the actual Mandala are not (yet).

Doing this also involved factoring out a `<SvgTransforms>` component, which makes setting up SVG transforms a bit easier.

Also moved `getSymbol` of `creature-page.tsx` and into `svg-vocabulary.tsx`, with the new name `getSvgSymbol`.
