### PR TITLE
Move eye creature to a separate debug page.

### DIFF
--- a/lib/browser-main.tsx
+++ b/lib/browser-main.tsx
@@ -4,12 +4,14 @@ import { WavesPage } from "./pages/waves-page";
 import { VocabularyPage } from "./pages/vocabulary-page";
 import { CreaturePage } from "./pages/creature-page";
 import { MandalaPage } from "./pages/mandala-page";
+import { DebugPage } from "./pages/debug-page";
 
 const Pages = {
   vocabulary: VocabularyPage,
   creature: CreaturePage,
   waves: WavesPage,
   mandala: MandalaPage,
+  debug: DebugPage,
 };
 
 type PageName = keyof typeof Pages;

--- a/lib/creature-symbol-factory.tsx
+++ b/lib/creature-symbol-factory.tsx
@@ -135,9 +135,7 @@ function getCreatureSymbol(
   return result;
 }
 
-export function extractCreatureSymbolFromElement(
-  el: JSX.Element
-): CreatureSymbol {
+function extractCreatureSymbolFromElement(el: JSX.Element): CreatureSymbol {
   if (isSimpleCreatureSymbolFC(el.type)) {
     return getCreatureSymbol(el.type.creatureSymbolData, el.props);
   }

--- a/lib/pages/debug-page.tsx
+++ b/lib/pages/debug-page.tsx
@@ -1,0 +1,77 @@
+import React, { useContext, useState } from "react";
+import { AutoSizingSvg } from "../auto-sizing-svg";
+import { CreatureContext, CreatureContextType } from "../creature-symbol";
+import { createCreatureSymbolFactory } from "../creature-symbol-factory";
+import { HoverDebugHelper } from "../hover-debug-helper";
+import { createSvgSymbolContext } from "../svg-symbol";
+import { svgScale, SvgTransforms } from "../svg-transform";
+import { getSvgSymbol } from "../svg-vocabulary";
+import { SymbolContextWidget } from "../symbol-context-widget";
+
+const symbol = createCreatureSymbolFactory(getSvgSymbol);
+
+const Eye = symbol("eye");
+
+const Hand = symbol("hand");
+
+const Arm = symbol("arm");
+
+const Antler = symbol("antler");
+
+const Crown = symbol("crown");
+
+const Wing = symbol("wing");
+
+const MuscleArm = symbol("muscle_arm");
+
+const Leg = symbol("leg");
+
+const Tail = symbol("tail");
+
+const Lightning = symbol("lightning");
+
+const EYE_CREATURE = (
+  <Eye>
+    <Lightning nestInside />
+    <Arm attachTo="arm" left>
+      <Wing attachTo="arm" left right />
+    </Arm>
+    <Arm attachTo="arm" right>
+      <MuscleArm attachTo="arm" left right />
+    </Arm>
+    <Antler attachTo="horn" left right />
+    <Crown attachTo="crown">
+      <Hand attachTo="horn" left right>
+        <Arm attachTo="arm" left />
+      </Hand>
+    </Crown>
+    <Leg attachTo="leg" left right />
+    <Tail attachTo="tail" invert />
+  </Eye>
+);
+
+export const DebugPage: React.FC<{}> = () => {
+  const [symbolCtx, setSymbolCtx] = useState(createSvgSymbolContext());
+  const defaultCtx = useContext(CreatureContext);
+  const ctx: CreatureContextType = {
+    ...defaultCtx,
+    ...symbolCtx,
+    fill: symbolCtx.showSpecs ? "none" : symbolCtx.fill,
+  };
+
+  return (
+    <>
+      <h1>Debug!</h1>
+      <SymbolContextWidget ctx={symbolCtx} onChange={setSymbolCtx} />
+      <CreatureContext.Provider value={ctx}>
+        <HoverDebugHelper>
+          <AutoSizingSvg padding={20}>
+            <SvgTransforms transforms={[svgScale(0.5)]}>
+              {EYE_CREATURE}
+            </SvgTransforms>
+          </AutoSizingSvg>
+        </HoverDebugHelper>
+      </CreatureContext.Provider>
+    </>
+  );
+};


### PR DESCRIPTION
Really the eye creature is only useful for me as a debugging tool, so this moves it over to a separate debug page.

It also removes the whole concept of randomizing the eye creature, mainly because it ignores all the rules set forth in the normal creature randomizer, so it's not terribly useful.

This simplifies the code for `creature-page.tsx` a bunch and hopefully makes it easier to understand.