### PR TITLE
Move SVG vocabulary from JSON to TS.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ dist
 dist-watch
 .cache
 lib/_svg-vocabulary.json
+lib/_svg-vocabulary.ts

--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,5 @@ node_modules
 dist
 dist-watch
 .cache
-lib/_svg-vocabulary.json
+lib/_svg-vocabulary-pretty-printed.json
 lib/_svg-vocabulary.ts

--- a/lib/svg-vocabulary.ts
+++ b/lib/svg-vocabulary.ts
@@ -1,7 +1,5 @@
 import type { SvgSymbolData } from "./svg-symbol";
 import { Vocabulary } from "./vocabulary";
-import _SvgVocabulary from "./_svg-vocabulary.json";
+import _SvgVocabulary from "./_svg-vocabulary.js";
 
-export const SvgVocabulary = new Vocabulary<SvgSymbolData>(
-  _SvgVocabulary as any
-);
+export const SvgVocabulary = new Vocabulary<SvgSymbolData>(_SvgVocabulary);

--- a/lib/svg-vocabulary.ts
+++ b/lib/svg-vocabulary.ts
@@ -1,5 +1,5 @@
 import type { SvgSymbolData } from "./svg-symbol";
 import { Vocabulary } from "./vocabulary";
-import _SvgVocabulary from "./_svg-vocabulary.js";
+import _SvgVocabulary from "./_svg-vocabulary";
 
 export const SvgVocabulary = new Vocabulary<SvgSymbolData>(_SvgVocabulary);

--- a/lib/vocabulary-builder.ts
+++ b/lib/vocabulary-builder.ts
@@ -12,7 +12,10 @@ const SUPPORTED_SVG_TAGS = new Set(SUPPORTED_SVG_TAG_ARRAY);
 
 const MY_DIR = __dirname;
 export const SVG_SYMBOLS_DIR = path.join(MY_DIR, "..", "assets", "symbols");
-const VOCAB_JSON_PATH = path.join(MY_DIR, "_svg-vocabulary.json");
+const VOCAB_JSON_PATH = path.join(
+  MY_DIR,
+  "_svg-vocabulary-pretty-printed.json"
+);
 const VOCAB_TS_PATH = path.join(MY_DIR, "_svg-vocabulary.ts");
 const SVG_EXT = ".svg";
 


### PR DESCRIPTION
Ugh, we need to write out a TypeScript file instead of importing the JSON directly because otherwise the TS compiler will spend an inordinate amount of time doing type inference, which massively slows down type-checking (especially in IDEs and such).

The TS file actually uses `JSON.parse` on a stringified version of the JSON instead of just inlining the JSON itself because [apparently it's much faster][1].

[1]: https://www.bram.us/2019/11/25/faster-javascript-apps-with-json-parse/