### PR TITLE
Add an 'Export PNG' button

### DIFF
--- a/lib/export-svg.tsx
+++ b/lib/export-svg.tsx
@@ -13,10 +13,7 @@ function getSvgMarkup(el: SVGSVGElement): string {
  * Initiates a download on the user's browser which downloads the given
  * SVG element under the given filename.
  */
-export function exportSvg(
-  filename: string,
-  svgRef: React.RefObject<SVGSVGElement>
-) {
+function exportSvg(filename: string, svgRef: React.RefObject<SVGSVGElement>) {
   const svgEl = svgRef.current;
   if (!svgEl) {
     alert("Oops, an error occurred! Please try again later.");
@@ -33,9 +30,44 @@ export function exportSvg(
   document.body.removeChild(anchor);
 }
 
+function exportPng(filename: string, svgRef: React.RefObject<SVGSVGElement>) {
+  const canvas = document.createElement("canvas");
+  const svgEl = svgRef.current;
+  if (!svgEl) {
+    alert("Oops, an error occurred! Please try again later.");
+    return;
+  }
+  const dataURL = `data:image/svg+xml;utf8,${encodeURIComponent(
+    getSvgMarkup(svgEl)
+  )}`;
+  const img = document.createElement("img");
+  img.onload = () => {
+    canvas.width = img.width;
+    canvas.height = img.height;
+    const ctx = canvas.getContext("2d");
+    if (!ctx) throw new Error("blah");
+    ctx.drawImage(img, 0, 0);
+    const dataURL = canvas.toDataURL();
+    const anchor = document.createElement("a");
+    anchor.href = dataURL;
+    anchor.download = filename;
+    document.body.append(anchor);
+    anchor.click();
+    document.body.removeChild(anchor);
+  };
+  img.src = dataURL;
+}
+
 export const ExportSvgButton: React.FC<{
   svgRef: React.RefObject<SVGSVGElement>;
   filename: string;
 }> = ({ svgRef, filename }) => (
-  <button onClick={() => exportSvg(filename, svgRef)}>Export SVG</button>
+  <>
+    <button onClick={() => exportSvg(filename, svgRef)}>Export SVG</button>{" "}
+    <button
+      onClick={() => exportPng(filename.replace(/\.svg$/, ".png"), svgRef)}
+    >
+      Export PNG
+    </button>
+  </>
 );

--- a/lib/export-svg.tsx
+++ b/lib/export-svg.tsx
@@ -58,15 +58,15 @@ function exportPng(filename: string, svgRef: React.RefObject<SVGSVGElement>) {
   img.src = dataURL;
 }
 
-export const ExportSvgButton: React.FC<{
+export const ExportWidget: React.FC<{
   svgRef: React.RefObject<SVGSVGElement>;
-  filename: string;
-}> = ({ svgRef, filename }) => (
+  basename: string;
+}> = ({ svgRef, basename }) => (
   <>
-    <button onClick={() => exportSvg(filename, svgRef)}>Export SVG</button>{" "}
-    <button
-      onClick={() => exportPng(filename.replace(/\.svg$/, ".png"), svgRef)}
-    >
+    <button onClick={() => exportSvg(`${basename}.svg`, svgRef)}>
+      Export SVG
+    </button>{" "}
+    <button onClick={() => exportPng(`${basename}.png`, svgRef)}>
       Export PNG
     </button>
   </>

--- a/lib/pages/creature-page.tsx
+++ b/lib/pages/creature-page.tsx
@@ -11,7 +11,7 @@ import { SymbolContextWidget } from "../symbol-context-widget";
 import { range } from "../util";
 
 import { AutoSizingSvg } from "../auto-sizing-svg";
-import { ExportSvgButton } from "../export-svg";
+import { ExportWidget } from "../export-svg";
 import {
   CreatureContext,
   CreatureContextType,
@@ -167,8 +167,8 @@ const MAX_COMPLEXITY_LEVEL = COMPLEXITY_LEVEL_GENERATORS.length - 1;
 
 const INITIAL_COMPLEXITY_LEVEL = 2;
 
-function getDownloadFilename(randomSeed: number) {
-  return `mystic-symbolic-creature-${randomSeed}.svg`;
+function getDownloadBasename(randomSeed: number) {
+  return `mystic-symbolic-creature-${randomSeed}`;
 }
 
 export const CreaturePage: React.FC<{}> = () => {
@@ -221,8 +221,8 @@ export const CreaturePage: React.FC<{}> = () => {
           <u>R</u>andomize!
         </button>{" "}
         <button onClick={() => window.location.reload()}>Reset</button>{" "}
-        <ExportSvgButton
-          filename={getDownloadFilename(randomSeed)}
+        <ExportWidget
+          basename={getDownloadBasename(randomSeed)}
           svgRef={svgRef}
         />
       </div>

--- a/lib/pages/mandala-page.tsx
+++ b/lib/pages/mandala-page.tsx
@@ -3,7 +3,7 @@ import { AutoSizingSvg } from "../auto-sizing-svg";
 import { getBoundingBoxCenter } from "../bounding-box";
 import { ColorWidget } from "../color-widget";
 import { DEFAULT_BG_COLOR } from "../colors";
-import { ExportSvgButton } from "../export-svg";
+import { ExportWidget } from "../export-svg";
 import { HoverDebugHelper } from "../hover-debug-helper";
 import { NumericSlider } from "../numeric-slider";
 import {
@@ -307,7 +307,7 @@ export const MandalaPage: React.FC<{}> = () => {
         <button accessKey="r" onClick={randomize}>
           <u>R</u>andomize!
         </button>{" "}
-        <ExportSvgButton filename="mandala.svg" svgRef={svgRef} />
+        <ExportWidget basename="mandala" svgRef={svgRef} />
       </div>
       <HoverDebugHelper>
         <AutoSizingSvg padding={20} ref={svgRef} bgColor={bgColor}>


### PR DESCRIPTION
This fixes #62.

This was a lot easier than I thought it'd be.  I'm pretty sure this kind of solution didn't exist several years ago, but I could be wrong.

## To do

- [x] Refactor things to be a lot more DRY.
- [x] Rename `ExportSvgButton` to `ExportImageWidget` and make it take a `basename` instead of a `filename`.
- [ ] This seems to work fine on the latest versions of Firefox and Chrome Canary, but it might be good to try it out on more browsers.