### PR TITLE
Factor out a SvgCompositionContext.

### DIFF
--- a/index.html
+++ b/index.html
@@ -71,6 +71,12 @@ ul.navbar li:last-child {
   background-color: rgba(255, 255, 255, 0.9);
 }
 
+.mandala-container label.checkbox {
+  display: block;
+  margin-top: 10px;
+  margin-bottom: 10px;
+}
+
 .mandala-container .color-widget {
   display: flex;
 }

--- a/lib/checkbox.tsx
+++ b/lib/checkbox.tsx
@@ -8,7 +8,7 @@ type CheckboxProps = {
 
 export const Checkbox: React.FC<CheckboxProps> = (props) => {
   return (
-    <label>
+    <label className="checkbox">
       <input
         type="checkbox"
         checked={props.value}

--- a/lib/svg-composition-context.tsx
+++ b/lib/svg-composition-context.tsx
@@ -1,4 +1,4 @@
-import React from "React";
+import React from "react";
 import { ColorWidget } from "./color-widget";
 import { DEFAULT_BG_COLOR } from "./colors";
 import { createRandomColorPalette } from "./random-colors";

--- a/lib/svg-composition-context.tsx
+++ b/lib/svg-composition-context.tsx
@@ -1,0 +1,60 @@
+import React from "React";
+import { ColorWidget } from "./color-widget";
+import { DEFAULT_BG_COLOR } from "./colors";
+import { createRandomColorPalette } from "./random-colors";
+import { createSvgSymbolContext, SvgSymbolContext } from "./svg-symbol";
+import {
+  SymbolContextWidget,
+  SymbolContextWidgetProps,
+} from "./symbol-context-widget";
+
+const DEFAULT_CONTEXT: SvgCompositionContext = {
+  background: DEFAULT_BG_COLOR,
+  ...createSvgSymbolContext(),
+};
+
+export type SvgCompositionContext = SvgSymbolContext & {
+  /** The background color of the composition, as a hex hash (e.g. '#ff0000'). */
+  background: string;
+};
+
+export function createSvgCompositionContext(
+  ctx: Partial<SvgCompositionContext> = {}
+): SvgCompositionContext {
+  return {
+    ...DEFAULT_CONTEXT,
+    ...ctx,
+  };
+}
+
+export type CompositionContextWidgetProps<
+  T extends SvgCompositionContext
+> = SymbolContextWidgetProps<T>;
+
+export function CompositionContextWidget<T extends SvgCompositionContext>({
+  ctx,
+  onChange,
+  children,
+}: CompositionContextWidgetProps<T>): JSX.Element {
+  const randomizeColors = () => {
+    const [background, stroke, fill] = createRandomColorPalette(3);
+    onChange({ ...ctx, background, stroke, fill });
+  };
+
+  const extra = (
+    <button accessKey="c" onClick={randomizeColors}>
+      Randomize <u>c</u>olors!
+    </button>
+  );
+
+  return (
+    <SymbolContextWidget ctx={ctx} onChange={onChange} extraButtons={extra}>
+      {children}
+      <ColorWidget
+        label="Background"
+        value={ctx.background}
+        onChange={(background) => onChange({ ...ctx, background })}
+      />{" "}
+    </SymbolContextWidget>
+  );
+}

--- a/lib/svg-symbol.tsx
+++ b/lib/svg-symbol.tsx
@@ -30,9 +30,23 @@ export type SvgSymbolElement = (
 };
 
 export type SvgSymbolContext = {
+  /** The stroke color of the symbol, as a hex hash (e.g. '#ff0000'). */
   stroke: string;
+
+  /** The fill color of the symbol, as a hex hash (e.g. '#ff0000'). */
   fill: string;
+
+  /**
+   * Whether or not to visibly show the specifications for the symbol,
+   * e.g. its attachment points, nesting boxes, and so on.
+   */
   showSpecs: boolean;
+
+  /**
+   * Whether or not to forcibly apply a uniform stroke width to all
+   * the shapes in the symbol.  If defined, the stroke width will
+   * *not* vary as the symbol is scaled.
+   */
   uniformStrokeWidth?: number;
 };
 
@@ -43,6 +57,11 @@ const DEFAULT_CONTEXT: SvgSymbolContext = {
   uniformStrokeWidth: DEFAULT_UNIFORM_STROKE_WIDTH,
 };
 
+/**
+ * If the given symbol context is visibly showing its specifications,
+ * return one with its fill color set to "none" so that the specs can
+ * be seen more easily.
+ */
 export function noFillIfShowingSpecs<T extends SvgSymbolContext>(ctx: T): T {
   return {
     ...ctx,
@@ -50,6 +69,9 @@ export function noFillIfShowingSpecs<T extends SvgSymbolContext>(ctx: T): T {
   };
 }
 
+/**
+ * Return a symbol context with the stroke and fill colors swapped.
+ */
 export function swapColors<T extends SvgSymbolContext>(ctx: T): T {
   return {
     ...ctx,

--- a/lib/symbol-context-widget.tsx
+++ b/lib/symbol-context-widget.tsx
@@ -4,11 +4,19 @@ import { ColorWidget } from "./color-widget";
 import { NumericSlider } from "./numeric-slider";
 import { SvgSymbolContext, swapColors } from "./svg-symbol";
 
-export const SymbolContextWidget: React.FC<{
-  ctx: SvgSymbolContext;
-  onChange: (value: SvgSymbolContext) => void;
+export type SymbolContextWidgetProps<T extends SvgSymbolContext> = {
+  ctx: T;
+  onChange: (value: T) => void;
   children?: any;
-}> = ({ ctx, children, onChange }) => {
+  extraButtons?: JSX.Element;
+};
+
+export function SymbolContextWidget<T extends SvgSymbolContext>({
+  ctx,
+  children,
+  onChange,
+  extraButtons,
+}: SymbolContextWidgetProps<T>): JSX.Element {
   const updateCtx = (updates: Partial<SvgSymbolContext>) => {
     onChange({ ...ctx, ...updates });
   };
@@ -29,6 +37,7 @@ export const SymbolContextWidget: React.FC<{
       <button onClick={() => updateCtx(swapColors(ctx))}>
         Swap stroke/fill
       </button>{" "}
+      {extraButtons}
       <Checkbox
         label="Show specs"
         value={ctx.showSpecs}
@@ -48,4 +57,4 @@ export const SymbolContextWidget: React.FC<{
       )}
     </div>
   );
-};
+}


### PR DESCRIPTION
This fixes #67 by making the background color selection/randomization code more DRY via the addition of a new `SvgCompositionContext` and a `CompositionContextWidget`.

It also documents the `SvgSymbolContext` type, and moves the "randomize colors" button closer to the actual colors.