### PR TITLE
Make animation duration changeable

### DIFF
--- a/lib/animation.ts
+++ b/lib/animation.ts
@@ -13,7 +13,7 @@ import { useEffect, useState } from "react";
  * Assumes that the animation is looping, so the percentage will
  * reset to zero once it has finished.
  */
-export function useAnimation(durationMs: number): number {
+export function useAnimationPct(durationMs: number): number {
   const [pct, setPct] = useState(0);
   const [lastTimestamp, setLastTimestamp] = useState<number | undefined>(
     undefined

--- a/lib/pages/mandala-page.tsx
+++ b/lib/pages/mandala-page.tsx
@@ -84,7 +84,7 @@ const DURATION_SECS: NumericRange = {
   step: 0.1,
 };
 
-const DEFAULT_DURATION_SECS = 2;
+const DEFAULT_DURATION_SECS = 3;
 
 const ExtendedMandalaCircle: React.FC<
   ExtendedMandalaCircleParams & SvgSymbolContext

--- a/lib/pages/mandala-page.tsx
+++ b/lib/pages/mandala-page.tsx
@@ -20,7 +20,7 @@ import {
 } from "../svg-composition-context";
 import { Page } from "../page";
 import { MandalaCircle, MandalaCircleParams } from "../mandala-circle";
-import { useAnimation } from "../use-animation";
+import { useAnimationPct } from "../animation";
 
 type ExtendedMandalaCircleParams = MandalaCircleParams & {
   scaling: number;
@@ -220,7 +220,7 @@ export const MandalaPage: React.FC<{}> = () => {
     setCircle2({ ...circle2, ...getRandomCircleParams(rng) });
   };
   const isAnimated = isAnyMandalaCircleAnimated([circle1, circle2]);
-  const animPct = useAnimation(isAnimated ? durationSecs * 1000 : 0);
+  const animPct = useAnimationPct(isAnimated ? durationSecs * 1000 : 0);
   const symbolCtx = noFillIfShowingSpecs(baseCompCtx);
 
   const circle2SymbolCtx = invertCircle2 ? swapColors(symbolCtx) : symbolCtx;

--- a/lib/use-animation.ts
+++ b/lib/use-animation.ts
@@ -14,24 +14,24 @@ import { useEffect, useState } from "react";
  * reset to zero once it has finished.
  */
 export function useAnimation(durationMs: number): number {
-  const [msElapsed, setMsElapsed] = useState(0);
+  const [pct, setPct] = useState(0);
   const [lastTimestamp, setLastTimestamp] = useState<number | undefined>(
     undefined
   );
 
   useEffect(() => {
     if (!durationMs) {
-      setMsElapsed(0);
+      setPct(0);
       setLastTimestamp(undefined);
       return;
     }
 
     const callback = (timestamp: number) => {
-      let timeDelta = 0;
       if (typeof lastTimestamp === "number") {
-        timeDelta = timestamp - lastTimestamp;
+        const timeDelta = timestamp - lastTimestamp;
+        const pctDelta = timeDelta / durationMs;
+        setPct((pct + pctDelta) % 1.0);
       }
-      setMsElapsed(msElapsed + timeDelta);
       setLastTimestamp(timestamp);
     };
     const timeout = requestAnimationFrame(callback);
@@ -39,7 +39,7 @@ export function useAnimation(durationMs: number): number {
     return () => {
       cancelAnimationFrame(timeout);
     };
-  }, [durationMs, msElapsed, lastTimestamp]);
+  }, [durationMs, pct, lastTimestamp]);
 
-  return durationMs > 0 ? (msElapsed % durationMs) / durationMs : 0;
+  return pct;
 }

--- a/lib/use-animation.ts
+++ b/lib/use-animation.ts
@@ -1,0 +1,45 @@
+import { useEffect, useState } from "react";
+
+/**
+ * A React hook that can be used for animation.
+ *
+ * Given a duration in milliseconds, returns the percentage through
+ * that duration that has passed as a floating-point number
+ * from 0.0 to 1.0.
+ *
+ * Changes in the returned value will be triggered by `requestAnimationFrame`,
+ * so they will likely be tied to the monitor's refresh rate.
+ *
+ * Assumes that the animation is looping, so the percentage will
+ * reset to zero once it has finished.
+ */
+export function useAnimation(durationMs: number): number {
+  const [msElapsed, setMsElapsed] = useState(0);
+  const [lastTimestamp, setLastTimestamp] = useState<number | undefined>(
+    undefined
+  );
+
+  useEffect(() => {
+    if (!durationMs) {
+      setMsElapsed(0);
+      setLastTimestamp(undefined);
+      return;
+    }
+
+    const callback = (timestamp: number) => {
+      let timeDelta = 0;
+      if (typeof lastTimestamp === "number") {
+        timeDelta = timestamp - lastTimestamp;
+      }
+      setMsElapsed(msElapsed + timeDelta);
+      setLastTimestamp(timestamp);
+    };
+    const timeout = requestAnimationFrame(callback);
+
+    return () => {
+      cancelAnimationFrame(timeout);
+    };
+  }, [durationMs, msElapsed, lastTimestamp]);
+
+  return durationMs > 0 ? (msElapsed % durationMs) / durationMs : 0;
+}


### PR DESCRIPTION
This adds a slider that allows the duration of the mandala animation to be changed (for #71).

In so doing, it also decouples the animation speed from the display's refresh rate.